### PR TITLE
fix(error): resolve session in HandleNotFound for role-aware 404 CTAs

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -131,6 +131,18 @@ func HandleAdmin(c *gin.Context) {
 }
 
 func HandleNotFound(c *gin.Context) {
+	// router.NoRoute fires outside the auth middleware groups, so the
+	// "user" context key would be empty even for logged-in users hitting
+	// an unknown URL. Resolve the session here so the error template
+	// can pick the right CTAs. Silent fail-through to the anonymous
+	// branch on any error (no cookie, expired session, etc).
+	if _, exists := c.Get("user"); !exists {
+		if token, err := c.Cookie("session"); err == nil {
+			if session, err := getDB(c).GetSession(token); err == nil {
+				c.Set("user", session.User)
+			}
+		}
+	}
 	c.Status(http.StatusNotFound)
 	renderTemplate(c, "error", gin.H{
 		"Title":   "Not Found",

--- a/main_test.go
+++ b/main_test.go
@@ -506,6 +506,52 @@ func TestNotFoundReturns404(t *testing.T) {
 	}
 }
 
+// TestNotFoundShowsAnonymousCTAsWhenLoggedOut pins the existing behavior
+// for unauthenticated users hitting an unknown URL: the error page
+// shows Sign in + Browse the catalog (kiosk).
+func TestNotFoundShowsAnonymousCTAsWhenLoggedOut(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	req, _ := http.NewRequest("GET", "/doesnotexist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "Sign in") {
+		t.Errorf("anonymous 404 should show Sign in CTA")
+	}
+	if strings.Contains(body, "Go back home") {
+		t.Errorf("anonymous 404 should not show logged-in CTA")
+	}
+}
+
+// TestNotFoundShowsLoggedInCTAsForUnknownURL pins the fix for
+// cs408-go-stack-vih: router.NoRoute fires outside the auth middleware
+// groups, so HandleNotFound must resolve the session itself so the
+// error template can show "Go back home" + "Browse the catalog"
+// instead of the anonymous Sign in CTA when the user is actually
+// logged in.
+func TestNotFoundShowsLoggedInCTAsForUnknownURL(t *testing.T) {
+	router, dm := setupTestRouter(t)
+	sess, _ := loginAs(t, dm, "staff_404_cta", "staff")
+
+	req, _ := http.NewRequest("GET", "/doesnotexist", nil)
+	req.AddCookie(sess)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "Go back home") {
+		t.Errorf("logged-in 404 should show Go back home CTA; body=%s", body)
+	}
+	if strings.Contains(body, "Sign in") {
+		t.Errorf("logged-in 404 should not show Sign in CTA")
+	}
+}
+
 func TestBookDetailNotFoundReturns404(t *testing.T) {
 	router, dm := setupTestRouter(t)
 	sess, _ := loginAs(t, dm, "admin", "admin")

--- a/templates/error.html
+++ b/templates/error.html
@@ -4,6 +4,7 @@
     <div class="fs-4 mb-3 text-muted">{{.Message}}</div>
     {{if .User}}
     <a href="/" class="btn btn-sm" style="color: #1e3a5f; border-color: #1e3a5f;">Go back home</a>
+    <a href="/catalog" class="btn btn-sm ms-2" style="color: #1e3a5f; border-color: #1e3a5f;">Browse the catalog</a>
     {{else}}
     <a href="/login" class="btn btn-sm" style="color: #1e3a5f; border-color: #1e3a5f;">Sign in</a>
     <a href="/kiosk" class="btn btn-sm ms-2" style="color: #1e3a5f; border-color: #1e3a5f;">Browse the catalog</a>


### PR DESCRIPTION
## Summary

`router.NoRoute(HandleNotFound)` is registered at the router level, outside the auth middleware groups. So when a logged-in user hits an unknown URL (e.g. typo, stale link), `c.Get("user")` is empty and the error template falls into the anonymous `Sign in` / `Browse catalog` branch -- jarring for someone who's already authenticated.

Fix: `HandleNotFound` resolves the session cookie itself (same lookup `RequireAuth` does) before rendering. Silent fail-through to the anonymous branch on any error (no cookie, invalid token, expired session). No redirect, no behavior change for anonymous users.

Also adds a "Browse the catalog" link to the logged-in branch so the page has parity with the anonymous version.

Discovered 2026-05-21 during manual test of PR #86 (wdy / overdue notice print system).

bd issue: `cs408-go-stack-vih` (P3 bug).

## Test plan (automatic)

- [x] `go build ./...` clean
- [x] `go test ./...` all green (~25s)
- [x] gofmt clean on touched files
- [x] security-review skill on branch diff: no findings >= 8 confidence

New tests (main_test.go):
- `TestNotFoundShowsAnonymousCTAsWhenLoggedOut` -- pins anonymous-branch behavior
- `TestNotFoundShowsLoggedInCTAsForUnknownURL` -- pins the fix; staff session + unknown URL shows "Go back home", not "Sign in"

## Test plan (manual)

Verify before merge:

- [x] **Logged out**: Visit `/some-fake-url` while signed out. Shows 404 + "Sign in" + "Browse the catalog" buttons.
- [x] **Logged in**: Sign in. Visit `/some-fake-url`. Shows 404 + "Go back home" + "Browse the catalog" buttons. Sign in button is absent.
- [x] **Handler-triggered 404**: Visit `/reports/overdue/patron/99999/notice` while signed in. Same logged-in CTAs (this path already worked before the fix; pin it didn't regress).

## Rollback notes

Single PR revert is safe. After revert, anonymous users still see the right CTAs; logged-in users go back to seeing Sign in on unknown-URL 404s (the pre-existing behavior).